### PR TITLE
Request 성능 측정 테스트 시도2

### DIFF
--- a/app-push-api/src/main/kotlin/com/flab/bigtrader/apppush/presentation/AppPushController.java
+++ b/app-push-api/src/main/kotlin/com/flab/bigtrader/apppush/presentation/AppPushController.java
@@ -1,8 +1,9 @@
 package com.flab.bigtrader.apppush.presentation;
 
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.flab.bigtrader.apppush.common.AppPushRequestCounter;
@@ -18,10 +19,10 @@ public class AppPushController {
 	private final AppPushRequestCounter appPushRequestCounter;
 
 	@PostMapping("/app-push")
-	public ResponseEntity<AppPushSendResponse> sendMessage() {
+	@ResponseStatus(HttpStatus.OK)
+	public AppPushSendResponse sendMessage() {
 		long count = appPushRequestCounter.increaseAndGet();
 
-		return ResponseEntity.ok()
-			.body(new AppPushSendResponse(count));
+		return new AppPushSendResponse(count);
 	}
 }

--- a/big-trader-api/src/main/kotlin/com/flab/bigtrader/apppush/infrastructure/DefaultAppPushClient.java
+++ b/big-trader-api/src/main/kotlin/com/flab/bigtrader/apppush/infrastructure/DefaultAppPushClient.java
@@ -7,6 +7,7 @@ import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -34,6 +35,7 @@ public class DefaultAppPushClient implements AppPushClient {
 		this.webClient = WebClient.create(this.appPushServerBaseUrl);
 	}
 
+	@Async
 	public AppPushSendResult sendAppPush(AppPushSendEvent appPushSendEvent) {
 		Mono<AppPushSendResult> resultMono = webClient.post()
 			.uri("/api/v1/app-push")

--- a/big-trader-api/src/main/kotlin/com/flab/bigtrader/apppush/presentation/AppPushController.java
+++ b/big-trader-api/src/main/kotlin/com/flab/bigtrader/apppush/presentation/AppPushController.java
@@ -24,7 +24,9 @@ public class AppPushController {
 
 	@PostMapping("/messages")
 	@ResponseStatus(HttpStatus.OK)
-	public void sendAppPush(@RequestBody AppPushRequest appPushRequest) {
-		AppPushSendResult appPushSendResult = appPushClient.sendAppPush(appPushRequest.toAppPushSendEvent());
+	public void sendAppPush(@RequestBody AppPushRequest appPushRequest) throws Exception {
+		for (int i = 0; i < 100_000; i++) {
+			AppPushSendResult appPushSendResult = appPushClient.sendAppPush(appPushRequest.toAppPushSendEvent());
+		}
 	}
 }

--- a/big-trader-api/src/main/kotlin/com/flab/bigtrader/common/configuration/AsyncThreadConfiguration.java
+++ b/big-trader-api/src/main/kotlin/com/flab/bigtrader/common/configuration/AsyncThreadConfiguration.java
@@ -1,0 +1,25 @@
+package com.flab.bigtrader.common.configuration;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncThreadConfiguration implements AsyncConfigurer {
+
+	@Override
+	public Executor getAsyncExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setThreadNamePrefix("big-trader-async");
+		executor.setCorePoolSize(10);
+		executor.setMaxPoolSize(100);
+		executor.initialize();
+
+		return executor;
+	}
+
+}


### PR DESCRIPTION
* 변경점
    * 동기 api -> Async 어노테이션을 사용하여 비동기 api로 변경
* 동기에서 비동기로 바꾸면서 들었던 의문점
    * 가용 쓰레드 모두 일하고 있고, 큐가 가득 찬 이후에 들어오는 요청에 대해서는 어떻게 처리해야하는지?
        * 가용 쓰레드를 증가 시켜 더 많은 요청을 처리 할 수 있지만 더 이상 증가 할 수 있는 쓰레드가 없는 상황 일때 사용자의 요청을 더 많이 처리 하기 위해선 어떻게 해야하는지? 
    * 비동기 쓰레드의 경우 시간 측정을 어떻게 해야하는지?
        * Mono를 Flux로 변경하여 작업이 다 완료될때 까지 기다려야 하는지...?
    
정리가 안되어서 일단은 러프하게 써봤습니다  🫠